### PR TITLE
Handle empty loops in Python transpiler

### DIFF
--- a/src/PythonTranspiler.cpp
+++ b/src/PythonTranspiler.cpp
@@ -43,6 +43,7 @@ void PythonTranspiler::startLoop()
 	m_outputFile << m_loopIndents << "while cells[ptr]:\n";
 	m_loopIndents += "\t";
 	++m_openLoops;
+	m_outputFile << m_loopIndents << "pass\n";
 }
 
 void PythonTranspiler::endLoop()


### PR DESCRIPTION
Well that was easy. Added a `pass` statement at the start of every loop.